### PR TITLE
Add missing dependency to `Scarb.toml`

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 
 [dependencies]
 alexandria_encoding = { git = "https://github.com/keep-starknet-strange/alexandria" }
+alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria" }
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest


### PR DESCRIPTION
`alexandria_data_structures` was missing, test wouldn't run without it