### PR TITLE
Feat/4 Cairo-2.5.x

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-scarb 2.4.3
-starknet-foundry 0.14.0
+scarb 2.5.4
+starknet-foundry 0.18.0
 python 3.9.18
 dojo 0.4.4

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -13,8 +13,8 @@ version = "0.1.0"
 alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "085f17c87cf6d168032ef5840c39b8e18012284f" }
 alexandria_encoding = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "085f17c87cf6d168032ef5840c39b8e18012284f" }
 alexandria_merkle_tree = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "085f17c87cf6d168032ef5840c39b8e18012284f" }
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "v0.8.0" }
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "v0.9.0" }
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.14.0" }
-starknet = "2.4.3"
+starknet = "2.5.3"
 webauthn_auth = { path = "crates/webauthn/auth" }
 webauthn_session = { path = "crates/webauthn/session" }

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -12,7 +12,7 @@ version = "0.1.0"
 [workspace.dependencies]
 alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria", tag="cairo-v2.5.4" }
 alexandria_encoding = { git = "https://github.com/keep-starknet-strange/alexandria",tag="cairo-v2.5.4" }
-alexandria_merkle_tree = { git = "https://github.com/keep-starknet-strange/alexandria", tag="cairo-v2.5.4" }
+alexandria_merkle_tree = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "085f17c87cf6d168032ef5840c39b8e18012284f" }
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "v0.9.0" }
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.18.0" }
 starknet = "2.5.3"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -10,11 +10,11 @@ edition = "2023_10"
 version = "0.1.0"
 
 [workspace.dependencies]
-alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "085f17c87cf6d168032ef5840c39b8e18012284f" }
-alexandria_encoding = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "085f17c87cf6d168032ef5840c39b8e18012284f" }
-alexandria_merkle_tree = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "085f17c87cf6d168032ef5840c39b8e18012284f" }
+alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria", tag="cairo-v2.5.4" }
+alexandria_encoding = { git = "https://github.com/keep-starknet-strange/alexandria",tag="cairo-v2.5.4" }
+alexandria_merkle_tree = { git = "https://github.com/keep-starknet-strange/alexandria", tag="cairo-v2.5.4" }
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "v0.9.0" }
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.14.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.18.0" }
 starknet = "2.5.3"
 webauthn_auth = { path = "crates/webauthn/auth" }
 webauthn_session = { path = "crates/webauthn/session" }

--- a/crates/cartridge_account/src/erc20.cairo
+++ b/crates/cartridge_account/src/erc20.cairo
@@ -57,7 +57,7 @@ mod ERC20 {
     }
 
     #[generate_trait]
-    #[external(v0)]
+    #[abi(per_item)]
     impl ExternalImpl of ExternalTrait {
         fn burn(ref self: ContractState, value: u256) {
             let caller = get_caller_address();

--- a/crates/cartridge_account/src/lib.cairo
+++ b/crates/cartridge_account/src/lib.cairo
@@ -240,6 +240,6 @@ mod Account {
 
     fn _execute_single_call(call: Call) -> Span<felt252> {
         let Call{to, selector, calldata } = call;
-        starknet::call_contract_syscall(to, selector, calldata.span()).unwrap()
+        starknet::call_contract_syscall(to, selector, calldata).unwrap()
     }
 }

--- a/crates/cartridge_account/src/lib.cairo
+++ b/crates/cartridge_account/src/lib.cairo
@@ -94,6 +94,7 @@ mod Account {
     // External
     //
 
+    // TODO: Remove this warning
     #[abi(embed_v0)]
     impl SRC6Impl of interface::ISRC6<ContractState> {
         fn __execute__(self: @ContractState, mut calls: Array<Call>) -> Array<Span<felt252>> {

--- a/crates/cartridge_account/src/lib.cairo
+++ b/crates/cartridge_account/src/lib.cairo
@@ -94,7 +94,7 @@ mod Account {
     // External
     //
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl SRC6Impl of interface::ISRC6<ContractState> {
         fn __execute__(self: @ContractState, mut calls: Array<Call>) -> Array<Span<felt252>> {
             // Avoid calls from other contracts
@@ -126,14 +126,14 @@ mod Account {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl DeclarerImpl of interface::IDeclarer<ContractState> {
         fn __validate_declare__(self: @ContractState, class_hash: felt252) -> felt252 {
             self.validate_ecdsa_transaction()
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl PublicKeyImpl of super::IPublicKey<ContractState> {
         fn get_public_key(self: @ContractState) -> felt252 {
             self.Account_public_key.read()

--- a/crates/cartridge_account/tests/test_account.cairo
+++ b/crates/cartridge_account/tests/test_account.cairo
@@ -92,7 +92,7 @@ impl TransferCallImpl of TransferCallTrait {
         let mut calldata = array![];
         calldata.append_serde(self.recipient);
         calldata.append_serde(self.amount);
-        Call { to: self.erc20, selector: selectors::transfer, calldata: calldata }
+        Call { to: self.erc20, selector: selectors::transfer, calldata: calldata.span() }
     }
 }
 

--- a/crates/cartridge_account/tests/test_account.cairo
+++ b/crates/cartridge_account/tests/test_account.cairo
@@ -121,7 +121,7 @@ fn test_account() {
 
     let recipient = contract_address_const::<0x123>();
     let call = TransferCall { erc20: erc20_address, recipient: recipient, amount: 200 }.to_call();
-    let ret = account.__execute__(array![call]);
+    let _ret = account.__execute__(array![call]);
 
     // Verify that the transfer of tokens was succesful
     assert(erc20.balance_of(account_address) == 800, 'Should have remained');

--- a/crates/webauthn/auth/src/component.cairo
+++ b/crates/webauthn/auth/src/component.cairo
@@ -62,13 +62,13 @@ mod webauthn_component {
         fn verify_webauthn_signer(
             self: @ComponentState<TContractState>, signature: WebauthnSignature, tx_hash: felt252,
         ) -> bool {
-            let pub = match self.get_webauthn_pub_key() {
-                Option::Some(pub) => pub,
+            let pub_key = match self.get_webauthn_pub_key() {
+                Option::Some(pub_key) => pub_key,
                 Option::None => { return false; }
             };
-            let pub_key = match Secp256r1Impl::secp256_ec_new_syscall(pub.x, pub.y) {
+            let pub_key = match Secp256r1Impl::secp256_ec_new_syscall(pub_key.x, pub_key.y) {
                 Result::Ok(pub_key) => pub_key,
-                Result::Err(e) => { return false; }
+                Result::Err(_) => { return false; }
             };
             let pub_key = match pub_key {
                 Option::Some(pub_key) => pub_key,

--- a/crates/webauthn/auth/src/webauthn.cairo
+++ b/crates/webauthn/auth/src/webauthn.cairo
@@ -45,7 +45,7 @@ trait WebauthnAuthenticatorTrait<T> {
 
 
 fn verify(
-    pub: Secp256r1Point, // public key as point on elliptic curve
+    pub_key: Secp256r1Point, // public key as point on elliptic curve
     r: u256, // 'r' part from ecdsa
     s: u256, // 's' part from ecdsa
     type_offset: usize, // offset to 'type' field in json
@@ -86,9 +86,9 @@ fn verify(
     // Compute message ready for verification.
     let result = concatenate(@authenticator_data, @client_data_hash);
 
-    match verify_ecdsa(pub, result, r, s) {
+    match verify_ecdsa(pub_key, result, r, s) {
         Result::Ok => Result::Ok(()),
-        Result::Err(e) => AuthnError::InvalidSignature.into()
+        Result::Err(_) => AuthnError::InvalidSignature.into()
     }
 }
 
@@ -148,7 +148,7 @@ fn find_and_verify_credential_source<
                 PublicKey
             >::into(store.retrieve_public_key(credential.raw_id))?;
             let pk_2 = match response.user_handle {
-                Option::Some(handle) => RTSEIntoRTAE::<
+                Option::Some(_handle) => RTSEIntoRTAE::<
                     PublicKey
                 >::into(store.retrieve_public_key(credential.raw_id))?,
                 Option::None => { return AuthnError::IdentifiedUsersMismatch.into(); },
@@ -245,6 +245,6 @@ fn verify_signature(
     };
     match verify_ecdsa(pub_key_point, concatenation, r, s) {
         Result::Ok => Result::Ok(()),
-        Result::Err(e) => AuthnError::InvalidSignature.into()
+        Result::Err(_) => AuthnError::InvalidSignature.into()
     }
 }

--- a/crates/webauthn/session/src/lib.cairo
+++ b/crates/webauthn/session/src/lib.cairo
@@ -114,7 +114,7 @@ mod session_component {
 
             // Hashing all the calls
             loop {
-                let pub_key = match calls.pop_front() {
+                let _pub_key = match calls.pop_front() {
                     Option::Some(single) => { leaves.append(compute_call_hash(@single)); },
                     Option::None(_) => { break; },
                 };


### PR DESCRIPTION
In this PR I've bumped the cairo version to 2.5.4 and also updated the dependencies. 
There are some cosmetic changes to the code to get rid of the warnings (mostly unused variable and `pub` being a reserved identifier). 
There was a fix to the merkle tree hasing in alexandria: https://github.com/keep-starknet-strange/alexandria/pull/277
This however breaks one of our tests and thus the version of alexandria merkle tree package was not bumped. Thus some (non-critical) warnings are emitted. I'll investigate it in a later PR.