### PR TITLE
Feat/5/2 Poseidon hash fix

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -11,8 +11,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria", tag="cairo-v2.5.4" }
-alexandria_encoding = { git = "https://github.com/keep-starknet-strange/alexandria",tag="cairo-v2.5.4" }
-alexandria_merkle_tree = { git = "https://github.com/keep-starknet-strange/alexandria", rev = "085f17c87cf6d168032ef5840c39b8e18012284f" }
+alexandria_encoding = { git = "https://github.com/keep-starknet-strange/alexandria", tag="cairo-v2.5.4" }
+alexandria_merkle_tree = { git = "https://github.com/keep-starknet-strange/alexandria", tag="cairo-v2.5.4" }
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", tag = "v0.9.0" }
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.18.0" }
 starknet = "2.5.3"

--- a/crates/account_sdk/src/session_token/hash.rs
+++ b/crates/account_sdk/src/session_token/hash.rs
@@ -1,5 +1,5 @@
 use starknet::{core::types::FieldElement, macros::felt};
-use starknet_crypto::PoseidonHasher;
+use starknet_crypto::{poseidon_hash, PoseidonHasher};
 
 use crate::abigen::account::{Call, SessionSignature};
 
@@ -17,13 +17,6 @@ const POLICY_TYPE_HASH: FieldElement =
     felt!("0x2f0026e78543f036f33e26a8f5891b88c58dc1e20cbbfaf0bb53274da6fa568");
 
 const STARKNET_MESSAGE_FELT: FieldElement = felt!("0x537461726b4e6574204d657373616765");
-
-fn hash_two_elements(a: FieldElement, b: FieldElement) -> FieldElement {
-    let mut hasher = PoseidonHasher::new();
-    hasher.update(a);
-    hasher.update(b);
-    hasher.finalize()
-}
 
 pub fn compute_session_hash(
     signature: SessionSignature,
@@ -89,9 +82,9 @@ pub fn compute_root(mut current_node: FieldElement, mut proof: Vec<FieldElement>
         // We need to check if the current node is smaller than the current element of the proof.
         // If it is, we need to swap the order of the hash.
         current_node = if current_node < proof_element {
-            hash_two_elements(current_node, proof_element)
+            poseidon_hash(current_node, proof_element)
         } else {
-            hash_two_elements(proof_element, current_node)
+            poseidon_hash(proof_element, current_node)
         };
     }
 }
@@ -129,9 +122,9 @@ fn get_next_level(nodes: &Vec<FieldElement>) -> Vec<FieldElement> {
         let right = nodes[i * 2 + 1];
 
         let node = if left < right {
-            hash_two_elements(left, right)
+            poseidon_hash(left, right)
         } else {
-            hash_two_elements(right, left)
+            poseidon_hash(right, left)
         };
         next_level.push(node);
     }

--- a/crates/account_sdk/src/session_token/hash.rs
+++ b/crates/account_sdk/src/session_token/hash.rs
@@ -142,11 +142,11 @@ fn get_next_level(nodes: &Vec<FieldElement>) -> Vec<FieldElement> {
 #[test]
 fn merkle_tree_poseidon_test() {
     // [Setup] Merkle tree.
-    let root = felt!("0x7abc09d19c8a03abd4333a23f7823975c7bdd325170f0d32612b8baa1457d47");
+    let root = felt!("0x48924a3b2a7a7b7cc1c9371357e95e322899880a6534bdfe24e96a828b9d780");
     let leaf = felt!("0x1");
     let valid_proof = vec![
         felt!("0x2"),
-        felt!("0x47ef3ad11ad3f8fc055281f1721acd537563ec134036bc4bd4de2af151f0832"),
+        felt!("0x338eb608d7e48306d01f5a8d4275dd85a52ba79aaf7a1a7b35808ba573c3669"),
     ];
     let leaves = vec![felt!("0x1"), felt!("0x2"), felt!("0x3")];
 

--- a/crates/account_sdk/src/session_token/hash.rs
+++ b/crates/account_sdk/src/session_token/hash.rs
@@ -115,7 +115,7 @@ fn compute_proof(mut nodes: Vec<FieldElement>, index: usize, proof: &mut Vec<Fie
     compute_proof(next_level, index_parent, proof)
 }
 
-fn get_next_level(nodes: &Vec<FieldElement>) -> Vec<FieldElement> {
+fn get_next_level(nodes: &[FieldElement]) -> Vec<FieldElement> {
     let mut next_level: Vec<FieldElement> = Vec::with_capacity(nodes.len() / 2);
     for i in 0..nodes.len() / 2 {
         let left = nodes[i * 2];

--- a/crates/webauthn/auth/src/ecdsa.cairo
+++ b/crates/webauthn/auth/src/ecdsa.cairo
@@ -1,6 +1,6 @@
 use core::array::ArrayTrait;
 use core::debug::PrintTrait;
-use core::starknet::secp256_trait::Secp256PointTrait;
+use core::starknet::secp256_trait::{Secp256PointTrait, is_signature_entry_valid};
 use starknet::secp256r1::Secp256r1Point;
 use starknet::secp256r1::Secp256r1Impl;
 use starknet::secp256r1::Secp256r1PointImpl;
@@ -39,7 +39,8 @@ fn verify_ecdsa(
 fn verify_hashed_ecdsa(
     public_key_pt: Secp256r1Point, msg_hash: u256, r: u256, s: u256
 ) -> Result<(), VerifyEcdsaError> {
-    if check_bounds(r, s) == false {
+    if !is_signature_entry_valid::<Secp256r1Point>(r)
+        || !is_signature_entry_valid::<Secp256r1Point>(s) {
         return Result::Err(VerifyEcdsaError::WrongArgument);
     }
 
@@ -94,21 +95,5 @@ impl ImplVerifyEcdsaErrorIntoFelt252 of Into<VerifyEcdsaError, felt252> {
             VerifyEcdsaError::InvalidSignature => 'Invalid Signature!',
             VerifyEcdsaError::SyscallError => 'Syscall Error!',
         }
-    }
-}
-
-#[derive(Drop)]
-fn check_bounds(r: u256, s: u256) -> bool {
-    let n = Secp256r1Impl::get_curve_size();
-    if r > n {
-        false
-    } else if s > n {
-        false
-    } else if r < 1 {
-        false
-    } else if s < 1 {
-        false
-    } else {
-        true
     }
 }


### PR DESCRIPTION
In the previous PR https://github.com/cartridge-gg/cairo-webauthn/pull/40, I've not bumped the version of the `alexandria_merkle_tree` crate due to one test failing. It turned out that the fix introduced [here](https://github.com/keep-starknet-strange/alexandria/pull/277) needed to be done in our code as well. This along with the update of the corresponding test (not the one that was failing) are the only changes included in this PR. 
