### PR TITLE
Webauthn account configurable origin

### DIFF
--- a/crates/account_sdk/src/tests/webauthn/utils.rs
+++ b/crates/account_sdk/src/tests/webauthn/utils.rs
@@ -119,6 +119,7 @@ where
                 self.signer.clone(),
                 self.address,
                 self.runner.client().chain_id().await.unwrap(),
+                "starknet".to_string()
             ),
         )
     }

--- a/crates/account_sdk/src/webauthn_signer/account.rs
+++ b/crates/account_sdk/src/webauthn_signer/account.rs
@@ -44,6 +44,7 @@ where
         signer: P256r1Signer,
         address: FieldElement,
         chain_id: FieldElement,
+        origin: String,
     ) -> Self {
         Self {
             provider,
@@ -51,8 +52,7 @@ where
             address,
             chain_id,
             block_id: BlockId::Tag(BlockTag::Latest),
-            // Not security critical, but should be agreed upon
-            origin: "starknet".to_string(),
+            origin,
         }
     }
 }


### PR DESCRIPTION
@piniom I wasn't sure why this was hardcoded, do you see any issue if we make origin configurable? I think we'd need to be able to set this for example to `cartridge.gg` or `localhost`